### PR TITLE
Three small fixes (don't move marker, require eglot, correctly call lsp-deferred)

### DIFF
--- a/org-src-context.el
+++ b/org-src-context.el
@@ -156,8 +156,12 @@ Choose between Eglot and LSP-mode."
            (format "Cannot create directory \"%s\", please use the :mkdirp header arg." fnd))))
       
       (setq buffer-file-name (concat (temporary-file-directory) tangle-file))
+      (pcase org-src-context-lsp-command
+	('eglot--maybe-activate-editing-mode
+	 (require 'eglot)
       (when-let ((current-server (eglot-current-server)))
-        (funcall org-src-context-lsp-command)))))
+	   (funcall org-src-context-lsp-command)))
+	('lsp-deferred (funcall org-src-context-lsp-command))))))
 
 (define-minor-mode org-src-context-mode
   "Toggle Org-Src-Context mode. When turned on, you can start persistent

--- a/org-src-context.el
+++ b/org-src-context.el
@@ -105,10 +105,13 @@ Choose between Eglot and LSP-mode."
                                           'read-only t
                                           'font-lock-face 'org-src-context-read-only)
                    do (insert code))
-          
+
+	  (set-marker-insertion-type org-src-context--before-block-marker nil)
+
           ;; Code blocks after the current one
           (cl-loop initially do (goto-char (marker-position org-src-context--after-block-marker))
                    for block in (cdr extra-blocks)
+
                    for code = (propertize (concat "\n" (nth 6 block)
                                                   (propertize "\n" 'rear-nonsticky t))
                                           'read-only t
@@ -159,7 +162,7 @@ Choose between Eglot and LSP-mode."
       (pcase org-src-context-lsp-command
 	('eglot--maybe-activate-editing-mode
 	 (require 'eglot)
-      (when-let ((current-server (eglot-current-server)))
+	 (when-let ((current-server (eglot-current-server)))
 	   (funcall org-src-context-lsp-command)))
 	('lsp-deferred (funcall org-src-context-lsp-command))))))
 


### PR DESCRIPTION
Thanks, for this piece of code, it works great! Although I implemented some small fixes here.

- before this MR, when inserting code at the start of the edit buffer, that code is not included when 'applying the changes' to the org file (because the beginning marker moves)
- the function eglot-current-server is not known when the eglot package is not yet loaded
- I guess calling the lsp-deferred command should not depend on the condition if some `eglot-current-server` exists

This MR contains fixes for these 3 minor issues.