### PR TITLE
Fix functionality when block has multiple kv-pairs

### DIFF
--- a/org-src-context.el
+++ b/org-src-context.el
@@ -72,7 +72,7 @@ Choose between Eglot and LSP-mode."
             (this-block-data
              (save-excursion
                (goto-char
-                (org-element-property :begin (org-element-at-point)))
+                (org-element-property :post-affiliated (org-element-at-point)))
                (car (org-babel-tangle-single-block 1 t))))
             (tangle-file (car this-block-data))
             (this-block (cadr this-block-data))


### PR DESCRIPTION
When a source block has keywords such as #+NAME: name, the `:begin` of the block is located at the first keyword. This causes `org-babel-tangle-single-block` to determine a wrong line number for the start of the source block contents, so that it is different from when using `org-babel-tangle-collect-blocks` to determine the first line, causing a failure in the `org-src-context--edit-src-ad` its logic.

This commit fixes it by making sure that the cursor is on the line starting with #+BEGIN_SRC line when the first line of contents gets determined via `org-babel-tangle-single-block`.

Simply, currently, add a line `#+NAME: name` directly above some src-block and edit it with context (without narrowing) to 'see the bug'. After this fix, the 'bug' will be gone :)